### PR TITLE
Support ghc-9.2

### DIFF
--- a/json-syntax.cabal
+++ b/json-syntax.cabal
@@ -45,6 +45,7 @@ library
     , scientific-notation >=0.1.2 && <0.2
     , text-short >=0.1.3 && <0.2
     , zigzag >=0.0.1
+    , word-compat
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall -O2

--- a/src/Json.hs
+++ b/src/Json.hs
@@ -53,7 +53,7 @@ import Data.Number.Scientific (Scientific)
 import Data.Primitive (ByteArray,MutableByteArray,SmallArray)
 import Data.Text.Short (ShortText)
 import GHC.Exts (Char(C#),Int(I#),gtWord#,ltWord#,word2Int#,chr#)
-import GHC.Word (Word8(W8#),Word16(W16#))
+import GHC.Word.Compat
 
 import qualified Prelude
 import qualified Data.Builder.ST as B

--- a/src/Json/Smile.hs
+++ b/src/Json/Smile.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE NamedFieldPuns #-}


### PR DESCRIPTION
This change enables building json-syntax with ghc-9.2.

Depends-On: https://github.com/byteverse/json-syntax/pull/11
Fixes: #12